### PR TITLE
Órarend lekérdezés javítása

### DIFF
--- a/lib/kreta/client.dart
+++ b/lib/kreta/client.dart
@@ -21,6 +21,7 @@ import 'package:filcnaplo/data/models/student.dart';
 import 'package:filcnaplo/data/models/user.dart';
 import 'package:filcnaplo/data/models/evaluation.dart';
 import 'package:filcnaplo/data/models/absence.dart';
+import 'package:intl/intl.dart';
 
 class KretaClient {
   var client = http.Client();
@@ -660,9 +661,11 @@ class KretaClient {
         BaseURL.kreta(instituteCode) +
             KretaEndpoints.timetable +
             "?datumTol=" +
-            from.toUtc().toIso8601String() +
+            DateFormat('yyyy-MM-dd').format(from) +
+            //from.toUtc().toIso8601String() +
             "&datumIg=" +
-            to.toUtc().toIso8601String(),
+            //to.toUtc().toIso8601String(),
+            DateFormat('yyyy-MM-dd').format(to),
         headers: {
           "Authorization": "Bearer $accessToken",
           "User-Agent": userAgent


### PR DESCRIPTION
Órarend lekérdezés javítása, mert a Kréta 400-as hibát kezdett dobni. Ha csak a dátumot adjuk át paraméterben az óra nélkül, akkor megjavul.